### PR TITLE
Added optional prefix to Pill filenames

### DIFF
--- a/placebo/__init__.py
+++ b/placebo/__init__.py
@@ -15,7 +15,7 @@
 from placebo.pill import Pill
 
 
-def attach(session, data_path, debug=False):
-    pill = Pill(debug=debug)
+def attach(session, data_path, prefix=None, debug=False):
+    pill = Pill(prefix=prefix, debug=debug)
     pill.attach(session, data_path)
     return pill

--- a/placebo/pill.py
+++ b/placebo/pill.py
@@ -53,6 +53,10 @@ class Pill(object):
     def mode(self):
         return self._mode
 
+    @property
+    def data_path(self):
+        return self._data_path
+
     def _set_logger(self, logger_name, level=logging.INFO):
         """
         Convenience function to quickly configure full debug output

--- a/placebo/pill.py
+++ b/placebo/pill.py
@@ -35,10 +35,11 @@ class Pill(object):
 
     clients = []
 
-    def __init__(self, debug=False):
+    def __init__(self, prefix=None, debug=False):
         if debug:
             self._set_logger(__name__, logging.DEBUG)
         self.filename_re = re.compile(r'.*\..*_(?P<index>\d+).json')
+        self.prefix = prefix
         self._uuid = str(uuid.uuid4())
         self._data_path = None
         self._mode = None
@@ -178,6 +179,8 @@ class Pill(object):
 
     def get_new_file_path(self, service, operation):
         base_name = '{}.{}'.format(service, operation)
+        if self.prefix:
+            base_name = '{}.{}'.format(self.prefix, base_name)
         LOG.debug('get_new_file_path: %s', base_name)
         index = 0
         glob_pattern = os.path.join(self._data_path, base_name + '*')
@@ -194,6 +197,8 @@ class Pill(object):
 
     def get_next_file_path(self, service, operation):
         base_name = '{}.{}'.format(service, operation)
+        if self.prefix:
+            base_name = '{}.{}'.format(self.prefix, base_name)
         LOG.debug('get_next_file_path: %s', base_name)
         next_file = None
         while next_file is None:

--- a/tests/unit/responses/saved/foo.ec2.DescribeAddresses_1.json
+++ b/tests/unit/responses/saved/foo.ec2.DescribeAddresses_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "Addresses": [
+            {
+                "PublicIp": "42.43.44.45",
+                "Domain": "vpc",
+                "AllocationId": "eipalloc-87654321"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "b0fe7bb2-6552-4ea8-8a36-9685044048ab"
+        }
+    }
+}

--- a/tests/unit/test_canned.py
+++ b/tests/unit/test_canned.py
@@ -58,3 +58,23 @@ class TestPlacebo(unittest.TestCase):
         self.assertEqual(len(result['KeyPairs']), 2)
         self.assertEqual(result['KeyPairs'][0]['KeyName'], 'FooBar')
         self.assertEqual(result['KeyPairs'][1]['KeyName'], 'FieBaz')
+
+    def test_prefix_new_file_path(self):
+        self.pill.prefix = 'foo'
+        service = 'ec2'
+        operation = 'DescribeAddresses'
+        filename = '{}.{}.{}_2.json'.format(self.pill.prefix, service,
+                                            operation)
+        target = os.path.join(self.data_path, filename)
+        self.assertEqual(self.pill.get_new_file_path(service, operation),
+                         target)
+
+    def test_prefix_next_file_path(self):
+        self.pill.prefix = 'foo'
+        service = 'ec2'
+        operation = 'DescribeAddresses'
+        filename = '{}.{}.{}_1.json'.format(self.pill.prefix, service,
+                                            operation)
+        target = os.path.join(self.data_path, filename)
+        self.assertEqual(self.pill.get_next_file_path(service, operation),
+                         target)


### PR DESCRIPTION
Added a `prefix` parameter to `Pill` objects, which is prepended to filenames used when saving or loading responses.

This is untested WIP for now, hoping someone (possibly me) can run with it to get this feature implemented and unit tested.

Fixes #20 
