### PR TITLE
placebo_dir environment variable instead of __file__

### DIFF
--- a/placebo/utils.py
+++ b/placebo/utils.py
@@ -3,8 +3,6 @@ import boto3
 import os
 import functools
 
-PLACEBO_DIR = os.path.join(os.path.dirname(__file__), 'placebo')
-
 
 def placebo_session(function):
     """
@@ -14,6 +12,7 @@ def placebo_session(function):
     Accepts the following environment variables to configure placebo:
     PLACEBO_MODE: set to "record" to record AWS calls and save them
     PLACEBO_PROFILE: optionally set an AWS credential profile to record with
+    PLACEBO_DIR: set the directory to record to / read from
     """
 
     @functools.wraps(function)
@@ -29,7 +28,9 @@ def placebo_session(function):
 
         self = args[0]
         prefix = self.__class__.__name__ + '.' + function.__name__
-        record_dir = os.path.join(PLACEBO_DIR, prefix)
+        base_dir = os.environ.get("PLACEBO_DIR", os.getcwd())
+        base_dir = os.path.join(base_dir, "placebo")
+        record_dir = os.path.join(base_dir, prefix)
 
         if not os.path.exists(record_dir):
             os.makedirs(record_dir)

--- a/placebo/utils.py
+++ b/placebo/utils.py
@@ -28,8 +28,8 @@ def placebo_session(function):
 
         self = args[0]
         prefix = self.__class__.__name__ + '.' + function.__name__
-        base_dir = os.environ.get("PLACEBO_DIR", os.getcwd())
-        base_dir = os.path.join(base_dir, "placebo")
+        base_dir = os.environ.get(
+            "PLACEBO_DIR", os.path.join(os.getcwd(), "placebo"))
         record_dir = os.path.join(base_dir, prefix)
 
         if not os.path.exists(record_dir):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -7,6 +7,7 @@ import mock
 
 from placebo.utils import placebo_session
 
+
 class TestUtils(unittest.TestCase):
 
     def setUp(self):
@@ -17,6 +18,7 @@ class TestUtils(unittest.TestCase):
                                        'aws_credentials')
         self.environ['AWS_SHARED_CREDENTIALS_FILE'] = credential_path
         self.environ['PLACEBO_MODE'] = 'record'
+        self.environ['PLACEBO_DIR'] = 'placebo_test_runs'
         self.session = boto3.Session(profile_name='foobar',
                                      region_name='us-west-2')
 
@@ -24,7 +26,7 @@ class TestUtils(unittest.TestCase):
     def test_decorator(self, session):
 
         # Tear it up..
-        PLACEBO_TEST_DIR = os.path.join(os.getcwd(),'placebo', 'placebo')
+        PLACEBO_TEST_DIR = os.path.join(os.getcwd(), 'placebo_test_runs')
         prefix = 'TestUtils.test_decorator'
         record_dir = os.path.join(PLACEBO_TEST_DIR, prefix)
         self.assertTrue(os.path.exists(record_dir))


### PR DESCRIPTION
This fixes the problem we talked about in PR #41. Default is now <current working directory>/placebo and you can set it with PLACEBO_DIR