### PR TITLE
handle timezones in datetimes

### DIFF
--- a/placebo/serializer.py
+++ b/placebo/serializer.py
@@ -12,10 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
+from datetime import datetime, timedelta, tzinfo
 from botocore.response import StreamingBody
 from six import StringIO
 
+class UTC(tzinfo):
+    """UTC"""
+
+    def utcoffset(self, dt):
+        return timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return timedelta(0)
+
+utc = UTC()
 
 def deserialize(obj):
     """Convert JSON dicts back into objects."""
@@ -28,7 +41,7 @@ def deserialize(obj):
         module_name = obj.pop('__module__')
     # Use getattr(module, class_name) for custom types if needed
     if class_name == 'datetime':
-        return datetime.datetime(**target)
+        return datetime(tzinfo=utc, **target)
     if class_name == 'StreamingBody':
         return StringIO(target['body'])
     # Return unrecognized structures as-is
@@ -44,7 +57,7 @@ def serialize(obj):
     except AttributeError:
         pass
     # Convert objects to dictionary representation based on type
-    if isinstance(obj, datetime.datetime):
+    if isinstance(obj, datetime):
         result['year'] = obj.year
         result['month'] = obj.month
         result['day'] = obj.day

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -16,13 +16,13 @@ import datetime
 import unittest
 import json
 
-from placebo.serializer import serialize, deserialize
+from placebo.serializer import serialize, deserialize, utc
 
 
 date_sample = {
     "LoginProfile": {
         "UserName": "baz",
-        "CreateDate": datetime.datetime(2015, 1, 4, 9, 1, 2, 0),
+        "CreateDate": datetime.datetime(2015, 1, 4, 9, 1, 2, 0, tzinfo=utc),
     }
 }
 


### PR DESCRIPTION
Boto3 returns timezone aware datetimes, so when doing date math with these objects operations fail with the mocked placebo data because it is generating timezone naive datetimes.

AWS API always returns times in UTC, so I didn't bother trying to modify the serializer, I just injected the UTC timezone.
