### PR TITLE
Add support for pickle serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ lambda.list_functions()
 ... mocked response will be returned
 ```
 
+#### Using pickle
+
+The responses can also be saved using pickle instead of JSON documents.
+This can be useful to avoid serialization problems with complex types in
+the responses.
+
+To enable the pickle format:
+```
+pill = pill = placebo.attach(session, record_format="pickle")
+```
+
 #### Manual Mocking
 
 You can also add mocked responses manually:
@@ -147,6 +158,11 @@ $ PLACEBO_MODE=record nosetests tests.tests:TestFoo.test_create_iam_roles
 You can optionally pass an AWS profile to use:
 ```bash
 $ PLACEBO_PROFILE=foo PLACEBO_MODE=record nosetests tests.tests:TestFoo.test_create_iam_roles
+```
+
+You can optionally set the record format to use:
+```bash
+$ PLACEBO_FORMAT=pickle PLACEBO_MODE=record nosetests tests.tests:TestFoo.test_create_iam_roles
 ```
 
 In this example, it has created the following JSON blobs:

--- a/placebo/__init__.py
+++ b/placebo/__init__.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 from placebo.pill import Pill
+from placebo.serializer import Format
 
 
-def attach(session, data_path, prefix=None, debug=False):
-    pill = Pill(prefix=prefix, debug=debug)
+def attach(session, data_path, prefix=None, debug=False, record_format=Format.JSON):
+    pill = Pill(prefix=prefix, debug=debug, record_format=record_format)
     pill.attach(session, data_path)
     return pill

--- a/placebo/serializer.py
+++ b/placebo/serializer.py
@@ -12,9 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import pickle
 import datetime
 from botocore.response import StreamingBody
 from six import StringIO
+
+
+class Format:
+    """
+    Serialization formats
+    """
+    JSON = "json"
+    PICKLE = "pickle"
+
+    DEFAULT = JSON
+    ALLOWED = [JSON, PICKLE]
 
 
 def deserialize(obj):
@@ -58,3 +71,29 @@ def serialize(obj):
         return result
     # Raise a TypeError if the object isn't recognized
     raise TypeError("Type not serializable")
+
+
+def json_serialize(obj, fp):
+    """ Serialize ``obj`` as a JSON formatted stream to ``fp`` """
+    json.dump(obj, fp, indent=4, default=serialize)
+
+
+def json_deserialize(fp):
+    """ Deserialize ``fp`` JSON content to a Python object."""
+    return json.load(fp, object_hook=deserialize)
+
+
+def get_serializer(serializer_format):
+    """ Get the serializer for a specific format """
+    if serializer_format == Format.JSON:
+        return json_serialize
+    if serializer_format == Format.PICKLE:
+        return pickle.dump
+
+
+def get_deserializer(serializer_format):
+    """ Get the deserializer for a specific format """
+    if serializer_format == Format.JSON:
+        return json_deserialize
+    if serializer_format == Format.PICKLE:
+        return pickle.load

--- a/placebo/utils.py
+++ b/placebo/utils.py
@@ -3,6 +3,8 @@ import boto3
 import os
 import functools
 
+from placebo.serializer import Format
+
 
 def placebo_session(function):
     """
@@ -32,10 +34,12 @@ def placebo_session(function):
             "PLACEBO_DIR", os.path.join(os.getcwd(), "placebo"))
         record_dir = os.path.join(base_dir, prefix)
 
+        record_format = os.environ.get('PLACEBO_FORMAT', Format.DEFAULT)
+
         if not os.path.exists(record_dir):
             os.makedirs(record_dir)
 
-        pill = placebo.attach(session, data_path=record_dir)
+        pill = placebo.attach(session, data_path=record_dir, record_format=record_format)
 
         if os.environ.get('PLACEBO_MODE') == 'record':
             pill.record()

--- a/tests/unit/test_canned.py
+++ b/tests/unit/test_canned.py
@@ -76,5 +76,5 @@ class TestPlacebo(unittest.TestCase):
         filename = '{0}.{1}.{2}_1.json'.format(self.pill.prefix, service,
                                             operation)
         target = os.path.join(self.data_path, filename)
-        self.assertEqual(self.pill.get_next_file_path(service, operation),
-                         target)
+        (file_path, _) = self.pill.get_next_file_path(service, operation)
+        self.assertEqual(file_path, target)


### PR DESCRIPTION
As I found several problems serializing complex data in JSON documents, as described in #48 #45 and with others types like Dynamodb Binary or Decimal data. I added an option to use pickle to store the responses instead of JSON documents.
Recording the responses in pickle format fixes all the complex types serialization issues.

The playback mode will look for the recorded responses in any of the supported formats, so you can use a mixed solution with JSON and pickle formats for different responses. All the previous generated  JSON documents will be valid.
