### PR TITLE
May not properly name recording files if the file name is a subset of…

### DIFF
--- a/placebo/pill.py
+++ b/placebo/pill.py
@@ -193,7 +193,7 @@ class Pill(object):
             base_name = '{0}.{1}'.format(self.prefix, base_name)
         LOG.debug('get_new_file_path: %s', base_name)
         index = 0
-        glob_pattern = os.path.join(self._data_path, base_name + '*')
+        glob_pattern = os.path.join(self._data_path, base_name + '_*')
         for file_path in glob.glob(glob_pattern):
             file_name = os.path.basename(file_path)
             m = self.filename_re.match(file_name)


### PR DESCRIPTION
… a recording name that already exists

If I have recordings like ec2.DeleteVpnConnectionRoute_1.json and ec2.DeleteVpnConnectionRoute_2.json already recorded then a recording for ec2.DeleteVpnConnection_1.json will never be created because the longer ones are matched by the file glob. Fixed by adding '_' to the end of the base_name to eliminate longer camel case recording names. Works for my use case but probably needs testing.

